### PR TITLE
Vcita2 7983 fix legacy subscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 # Releases 
 
+## 1.0.1 (2025-07-16)
+### Fixed
+- **Legacy Subscription**: Fixed `@LegacySubscribeTo` decorator to use the correct legacy exchange (`eventBusConfig.legacy.exchange`) instead of the standard exchange (`eventBusConfig.exchange`)
+
 ## 1.0.0 (2025-07-14)
 ### Initial Stable Release
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vcita/event-bus-nestjs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vcita/event-bus-nestjs",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@golevelup/nestjs-rabbitmq": "1.20.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcita/event-bus-nestjs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Event Bus for NestJS applications with AMQP support",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/modules/subscriber/decorators/legacy-subscribe-to.decorator.ts
+++ b/src/modules/subscriber/decorators/legacy-subscribe-to.decorator.ts
@@ -56,7 +56,7 @@ export function LegacySubscribeTo(options: LegacySubscribeToOptions) {
 
   const errorHandler = createEventRetryHandler(logger, queueConfig);
   const rabbitConfig = EventBusDecoratorUtils.buildRabbitConfig(
-    eventBusConfig.exchange,
+    eventBusConfig.legacy.exchange,
     queueConfig,
     mainQueueOptions,
     errorHandler,


### PR DESCRIPTION
This pull request includes a patch update (v1.0.1) for the `@vcita/event-bus-nestjs` package. The update fixes an issue with the `@LegacySubscribeTo` decorator, ensuring it uses the correct legacy exchange configuration instead of the standard exchange.

### Bug Fixes:

* **Legacy Subscription**: Updated the `@LegacySubscribeTo` decorator in `src/modules/subscriber/decorators/legacy-subscribe-to.decorator.ts` to use `eventBusConfig.legacy.exchange` for legacy exchanges instead of `eventBusConfig.exchange`.

### Version Update:

* **Version bump**: Changed the package version in `package.json` from `1.0.0` to `1.0.1` to reflect the patch update.

### Documentation Update:

* **Changelog**: Added a new entry in `CHANGELOG.md` under version `1.0.1` to document the fix for the `@LegacySubscribeTo` decorator.