### PR TITLE
Vcita2 7983 fix legacy subscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 # Releases 
 
+## 1.0.2 (2025-07-17)
+### Changed
+- **Documentation**: Updated README to properly document PublisherModule and SubscriberModule instead of EventBusModule, reflecting the actual modular architecture and providing clear examples for different usage scenarios (publish-only, subscribe-only, or both)
+
 ## 1.0.1 (2025-07-16)
 ### Fixed
 - **Legacy Subscription**: Fixed `@LegacySubscribeTo` decorator to use the correct legacy exchange (`eventBusConfig.legacy.exchange`) instead of the standard exchange (`eventBusConfig.exchange`)

--- a/README.md
+++ b/README.md
@@ -43,16 +43,48 @@ npm install @nestjs/common @nestjs/core @vcita/infra-nestjs @vcita/oauth-client-
 
 ## Quick Start
 
-### 1. Import the Module
+### 1. Import the Modules
 
+You can import the modules individually based on your needs:
+
+**For Publishing Only:**
 ```typescript
 // app.module.ts
 import { Module } from '@nestjs/common';
-import { EventBusModule } from '@vcita/event-bus-nestjs';
+import { PublisherModule } from '@vcita/event-bus-nestjs';
 
 @Module({
   imports: [
-    EventBusModule,
+    PublisherModule,
+  ],
+})
+export class AppModule {}
+```
+
+**For Subscribing Only:**
+```typescript
+// app.module.ts
+import { Module } from '@nestjs/common';
+import { SubscriberModule } from '@vcita/event-bus-nestjs';
+
+@Module({
+  imports: [
+    SubscriberModule,
+  ],
+})
+export class AppModule {}
+```
+
+**For Both Publishing and Subscribing:**
+```typescript
+// app.module.ts
+import { Module } from '@nestjs/common';
+import { PublisherModule, SubscriberModule } from '@vcita/event-bus-nestjs';
+
+@Module({
+  imports: [
+    PublisherModule,
+    SubscriberModule,
   ],
 })
 export class AppModule {}
@@ -119,11 +151,11 @@ Don't forget to register your subscriber in your module:
 ```typescript
 // app.module.ts
 import { Module } from '@nestjs/common';
-import { EventBusModule } from '@vcita/event-bus-nestjs';
+import { SubscriberModule } from '@vcita/event-bus-nestjs';
 import { UserSubscriber } from './user.subscriber';
 
 @Module({
-  imports: [EventBusModule],
+  imports: [SubscriberModule],
   providers: [UserSubscriber], // Add your subscribers here
 })
 export class AppModule {}
@@ -438,7 +470,7 @@ In test environments (`NODE_ENV=test`), the module automatically mocks AMQP conn
 ```typescript
 // my.service.spec.ts
 import { Test } from '@nestjs/testing';
-import { EventBusModule, EventBusPublisher } from '@vcita/event-bus-nestjs';
+import { PublisherModule, EventBusPublisher } from '@vcita/event-bus-nestjs';
 
 describe('MyService', () => {
   let service: MyService;
@@ -446,7 +478,7 @@ describe('MyService', () => {
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
-      imports: [EventBusModule], // No configuration needed in tests
+      imports: [PublisherModule], // No configuration needed in tests
       providers: [MyService],
     }).compile();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vcita/event-bus-nestjs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vcita/event-bus-nestjs",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "ISC",
       "dependencies": {
         "@golevelup/nestjs-rabbitmq": "1.20.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcita/event-bus-nestjs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Event Bus for NestJS applications with AMQP support",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This pull request introduces updates to the documentation and package version to reflect a modular architecture for the Event Bus in NestJS applications. The changes focus on providing clearer examples for using the `PublisherModule` and `SubscriberModule` independently or together, ensuring the documentation aligns with the updated modular design.

### Documentation Updates:

* **README.md**: Updated examples to demonstrate the use of `PublisherModule` and `SubscriberModule` instead of the monolithic `EventBusModule` for various scenarios (publish-only, subscribe-only, or both). This includes changes in module imports and test environment setup. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L46-R87) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L122-R158) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L441-R481)

* **CHANGELOG.md**: Documented the changes in version `1.0.2`, highlighting the updated README and its alignment with the modular architecture.

### Package Version Update:

* **package.json**: Incremented the package version from `1.0.1` to `1.0.2` to reflect the documentation improvements.