### PR TITLE
Vcita2 8634

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 # Unreleased
+### Fixed
+- **Environment Control**: Fixed `DISABLE_EVENT_BUS` environment variable to properly disable RabbitMQ module import in SubscriberModule, completing the event bus disable functionality
 
 ---
 # Releases 

--- a/src/modules/subscriber/subscriber.module.ts
+++ b/src/modules/subscriber/subscriber.module.ts
@@ -18,7 +18,7 @@ import { eventBusConfig } from '../../configuration';
         enabled: false,
       },
     }),
-    ...(process.env.NODE_ENV !== 'test'
+    ...(process.env.NODE_ENV !== 'test' && process.env.DISABLE_EVENT_BUS !== 'true'
       ? [
           RabbitMQModule.forRoot(RabbitMQModule, {
             uri: eventBusConfig.rabbitmqDsn,


### PR DESCRIPTION
This pull request fixes an issue where setting the `DISABLE_EVENT_BUS` environment variable did not fully disable the event bus functionality as intended. The change ensures that the RabbitMQ module is not imported when `DISABLE_EVENT_BUS` is set to `'true'`.

**Environment control improvements:**

* Updated `src/modules/subscriber/subscriber.module.ts` to prevent the import of `RabbitMQModule` when `DISABLE_EVENT_BUS` is set to `'true'`, ensuring the event bus can be reliably disabled via environment configuration.
* Added a changelog entry in `CHANGELOG.md` documenting the fix for the `DISABLE_EVENT_BUS` environment variable and its effect on the event bus functionality.