### PR TITLE
VCITA2-9597 Add NonRetryableError export to index.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 # Unreleased
 
+### Fixed
+- **Exports**: Added missing `NonRetryableError` export to main package index, making it importable as documented in README examples
+
 ---
 # Releases 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,3 +24,6 @@ export { EventBusConfig } from './interfaces/event-bus-config.interface';
 // Decorator exports
 export { SubscribeTo } from './modules/subscriber/decorators/subscribe-to.decorator';
 export { LegacySubscribeTo } from './modules/subscriber/decorators/legacy-subscribe-to.decorator';
+
+// Error exports
+export { NonRetryableError } from './utils/event-retry-handler';


### PR DESCRIPTION
This pull request adds a new export to the package, making the `NonRetryableError` class available for external use. This change improves error handling capabilities for consumers of the package.

* Error handling improvement:
  * Added export for `NonRetryableError` from `src/utils/event-retry-handler`, allowing external modules to handle non-retryable errors raised by the event bus.