### PR TITLE
fix: parse actor JSON string from RabbitMQ headers in SubscribeTo decorator

### DIFF
--- a/src/modules/subscriber/decorators/subscribe-to.decorator.ts
+++ b/src/modules/subscriber/decorators/subscribe-to.decorator.ts
@@ -80,7 +80,10 @@ export function SubscribeTo(options: SubscribeToOptions) {
       amqpMsg: ConsumeMessage,
     ): Promise<void> {
       const headers = amqpMsg.properties.headers || {};
-      const actor = plainToActor(headers.actor) as ActorEntity;
+      // Parse actor from JSON string if needed (headers come as strings from RabbitMQ)
+      const actorData =
+        typeof headers.actor === 'string' ? JSON.parse(headers.actor) : headers.actor;
+      const actor = plainToActor(actorData) as ActorEntity;
       const auth = new AuthorizationPayloadEntity(null, actor);
       return originalEventHandler.call(this, auth, event, headers);
     };


### PR DESCRIPTION
## Summary

- Fixes actor deserialization bug in `@SubscribeTo` decorator
- Actor was being passed as JSON string to `plainToActor()` instead of parsed object
- This caused `actor.uid` and `actor.getBelongTo()` to return `undefined`

## Problem

When events are published to RabbitMQ, the actor object is serialized as a JSON string in the message headers:

```
headers.actor = '{"uid":"staff-123","type":"staff","belongsTo":{"uid":"biz-456","type":"business"}}'
```

The `@SubscribeTo` decorator was passing this **string** directly to `plainToActor()`:

```typescript
// BEFORE (broken)
const actor = plainToActor(headers.actor);  // headers.actor is a STRING!
```

`plainToActor()` expects an object, so accessing `actor.uid` on a string returns `undefined`:

```javascript
"some-string".uid  // → undefined
```

This resulted in an `ActorEntity` with all undefined properties, breaking any code that needed authenticated API calls.

## Fix

Parse the JSON string before passing to `plainToActor()`:

```typescript
// AFTER (fixed)
const actorData = typeof headers.actor === 'string' 
  ? JSON.parse(headers.actor) 
  : headers.actor;
const actor = plainToActor(actorData);
```

## Why This Wasn't Caught Earlier

The only other service using `@SubscribeTo` (`availability/ResourceSubscriber`) doesn't use the `auth` parameter - it only uses `event.data`. This bug only affects subscribers that need the actor for authenticated API calls.
