### PR TITLE
2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 # Releases 
 
+## 2.0.1 (2026-02-04)
+### Fixed
+- **Actor Deserialization**: Fixed `@SubscribeTo` decorator to properly parse actor from RabbitMQ headers. Actor was being passed as JSON string to `plainToActor()` instead of parsed object, causing `actor.uid` and `actor.getBelongTo()` to return `undefined`.
+
 ## 2.0.0 (2025-09-28)
 ### BREAKING CHANGES
 - **Publisher Validation**: `prevData` is now **required** for `updated` events

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vcita/event-bus-nestjs",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vcita/event-bus-nestjs",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "@golevelup/nestjs-rabbitmq": "1.20.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcita/event-bus-nestjs",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Event Bus for NestJS applications with AMQP support",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Changelog update for actor deserialization fix
- Version bump to 2.0.1

## Changes

### Fixed
- **Actor Deserialization**: Fixed `@SubscribeTo` decorator to properly parse actor from RabbitMQ headers. Actor was being passed as JSON string to `plainToActor()` instead of parsed object, causing `actor.uid` and `actor.getBelongTo()` to return `undefined`.