### PR TITLE
Export getCurrentAttemptCount for subscriber retry awareness

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,5 +26,5 @@ export { EventBusConfig } from './interfaces/event-bus-config.interface';
 export { SubscribeTo } from './modules/subscriber/decorators/subscribe-to.decorator';
 export { LegacySubscribeTo } from './modules/subscriber/decorators/legacy-subscribe-to.decorator';
 
-// Error exports
-export { NonRetryableError } from './utils/event-retry-handler';
+// Error & retry exports
+export { NonRetryableError, getCurrentAttemptCount } from './utils/event-retry-handler';

--- a/src/modules/subscriber/interceptors/event-bus-processing.interceptor.ts
+++ b/src/modules/subscriber/interceptors/event-bus-processing.interceptor.ts
@@ -16,7 +16,7 @@ import {
   EventBusMetricsService,
   ValidationFailureType,
 } from '../services/event-bus-metrics.service';
-import { NonRetryableError, RetryError } from '../../../utils/event-retry-handler';
+import { NonRetryableError, RetryError, getCurrentAttemptCount } from '../../../utils/event-retry-handler';
 
 @Injectable()
 export class EventBusProcessingInterceptor implements NestInterceptor {
@@ -165,7 +165,7 @@ export class EventBusProcessingInterceptor implements NestInterceptor {
       return throwError(error);
     }
 
-    const attemptNumber = EventBusProcessingInterceptor.getCurrentAttemptCount(amqpMsg);
+    const attemptNumber = getCurrentAttemptCount(amqpMsg.properties.headers || {});
     const maxRetries = metadata.options.retry?.count ?? eventBusConfig.retry?.defaultMaxRetries;
 
     if (attemptNumber > maxRetries) {
@@ -188,31 +188,4 @@ export class EventBusProcessingInterceptor implements NestInterceptor {
     );
   }
 
-  /**
-   * Get the current attempt count for a message
-   * @param amqpMsg - The AMQP message
-   * @returns The current message attempt count, including the initial attempt
-   */
-  private static getCurrentAttemptCount(amqpMsg: ConsumeMessage): number {
-    // RabbitMQ's x-death header: Array tracking each dead-letter event for this message
-    // Each entry contains: { queue, reason, time, exchange, routing-keys, count }
-    const deadLetterHistory = amqpMsg.properties.headers?.['x-death'] || [];
-    if (deadLetterHistory.length === 0) {
-      return 1;
-    }
-
-    // RabbitMQ's x-first-death-queue header: Name of the first queue that dead-lettered this message
-    // In our case, this is the original subscriber queue (before any retries)
-    const originalSubscriberQueue = amqpMsg.properties.headers?.['x-first-death-queue'] || '';
-
-    // Find the x-death entry for the original subscriber queue to get its dead-letter count
-    // This count represents how many times the original queue failed and dead-lettered the message
-    const originalQueueDeathEntry = deadLetterHistory.find(
-      (deathEntry: any) => deathEntry.queue === originalSubscriberQueue,
-    );
-    const originalQueueDeathCount = originalQueueDeathEntry?.count || 0;
-
-    // Return the current attempt number (previous death count + 1)
-    return originalQueueDeathCount + 1;
-  }
 }

--- a/src/utils/event-retry-handler.ts
+++ b/src/utils/event-retry-handler.ts
@@ -48,6 +48,28 @@ export class RetryError extends EventError {
   }
 }
 
+/**
+ * Get the current attempt number for a message based on RabbitMQ's x-death headers.
+ * Returns 1 for the first attempt (no prior failures), 2 after one retry, etc.
+ *
+ * @param headers - The message headers (from amqpMsg.properties.headers or EventHeaders)
+ * @returns The current attempt number (1-based)
+ */
+export function getCurrentAttemptCount(headers: Record<string, any>): number {
+  const deadLetterHistory = headers?.['x-death'] || [];
+  if (!Array.isArray(deadLetterHistory) || deadLetterHistory.length === 0) {
+    return 1;
+  }
+
+  const originalSubscriberQueue = headers?.['x-first-death-queue'] || '';
+  const originalQueueDeathEntry = deadLetterHistory.find(
+    (deathEntry: any) => deathEntry.queue === originalSubscriberQueue,
+  );
+  const originalQueueDeathCount = originalQueueDeathEntry?.count || 0;
+
+  return originalQueueDeathCount + 1;
+}
+
 export const RetryHeaders = {
   RETRY_LATEST_TIMESTAMP: 'x-retry-latest-timestamp',
   RETRY_ORIGINAL_ERROR: 'x-retry-original-error',


### PR DESCRIPTION
## Summary
- Extract `getCurrentAttemptCount` from `EventBusProcessingInterceptor` into a standalone exported utility in `event-retry-handler.ts`
- Export it from the package index so subscribers can determine which retry attempt they are on
- Refactor the interceptor to use the shared utility (no behavior change)

## Motivation
Subscribers sometimes need to know if the current attempt is the final retry — for example, to publish a failure event to notify downstream services only after all retries are exhausted. Currently `getCurrentAttemptCount` is a private static method on the interceptor and not accessible to application code.

## Usage
```typescript
import { getCurrentAttemptCount } from '@vcita/event-bus-nestjs';

// In a subscriber handler:
const attemptNumber = getCurrentAttemptCount(headers as Record<string, any>);
const maxRetries = parseInt(process.env.EVENT_BUS_DEFAULT_MAX_RETRIES || '1', 10);
if (attemptNumber > maxRetries) {
  await this.publishFailureEvent(...);
}
```

## Changes
- `src/utils/event-retry-handler.ts` — added exported `getCurrentAttemptCount(headers)` function
- `src/modules/subscriber/interceptors/event-bus-processing.interceptor.ts` — removed private static method, uses shared utility
- `src/index.ts` — added `getCurrentAttemptCount` to exports


Made with [Cursor](https://cursor.com)